### PR TITLE
Restore `build` method on `Builder` and `Parameter` to restore backwards compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1]
+
+### Added
+
+- Restore `build` method on `Builder` and `Parameter` to restore backwards compatibility with previous versions.
+
 ## [2.0.0]
 
 ### Added

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -32,6 +32,11 @@ class Builder implements Stringable
         return $this;
     }
 
+    public function build(): string
+    {
+        return $this->toString();
+    }
+
     public function toString(): string
     {
         return implode(

--- a/src/Parameter.php
+++ b/src/Parameter.php
@@ -12,6 +12,11 @@ class Parameter implements Stringable
     ) {
     }
 
+    public function build(): string
+    {
+        return $this->toString();
+    }
+
     public function toString(): string
     {
         return sprintf(


### PR DESCRIPTION
# Changes

### Added

- Restore `build` method on `Builder` and `Parameter` to restore backwards compatibility with previous versions.
